### PR TITLE
typo in metadata example

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -16,7 +16,7 @@ prepped_data <- PrepareCyteTypeR(pbmc,
 metadata <- list(
   title = 'My scRNA-seq analysis of human pbmc',
   run_label = 'initial_analysis',
-  experiment_name: 'pbmc_human_samples_study')
+  experiment_name = 'pbmc_human_samples_study')
 
 results <- CyteTypeR(prepped_data = prepped_data, 
                           study_context = "pbmc blood samples from humans", 

--- a/vignettes/get-started.Rmd
+++ b/vignettes/get-started.Rmd
@@ -48,7 +48,7 @@ prepped_data <- PrepareCyteTypeR(pbmc,
 metadata <- list(
   title = 'My scRNA-seq analysis of human pbmc',
   run_label = 'initial_analysis',
-  experiment_name: 'pbmc_human_samples_study')
+  experiment_name = 'pbmc_human_samples_study')
 
 results <- CyteTypeR(prepped_data = prepped_data, 
                           study_context = "pbmc blood samples from humans", 


### PR DESCRIPTION
changed ':' to '=' for experiment name in get-started